### PR TITLE
[time-killer]Fix some problems not resolved by the new API, fixes #3

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/IterativeWindowStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/IterativeWindowStream.java
@@ -218,9 +218,14 @@ public class IterativeWindowStream<IN, IN_W extends Window, F, K, R, S, STATE> {
 
 		WindowLoopFunction coWinTerm;
 		private ManagedLoopStateHandl managedLoopStateHandl;
+		private WindowMultiPassOperator windowMultiPassOperator;
 
 		public void setManagedLoopStateHandl(ManagedLoopStateHandl managedLoopStateHandl) {
 			this.managedLoopStateHandl = managedLoopStateHandl;
+		}
+
+		public void setWindowMultiPassOperator(WindowMultiPassOperator windowMultiPassOperator) {
+			this.windowMultiPassOperator = windowMultiPassOperator;
 		}
 
 		public StepWindowFunction(WindowLoopFunction coWinTerm) {
@@ -228,6 +233,7 @@ public class IterativeWindowStream<IN, IN_W extends Window, F, K, R, S, STATE> {
 		}
 
 		public void apply(K key, W window, Iterable<IN> input, Collector<OUT> out) throws Exception {
+			windowMultiPassOperator.setCurrentKey(key);
 			coWinTerm.step(new LoopContext(window.getTimeContext(), window.getEnd(), key, (StreamingRuntimeContext) getRuntimeContext(), managedLoopStateHandl), input, out);
 		}
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowMultiPassOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowMultiPassOperator.java
@@ -105,9 +105,10 @@ public class WindowMultiPassOperator<K, IN1, IN2, R, S, W2 extends Window>
 
 		@Override
 		public void markActive(List<Long> context, K key) {
-			if(activeKeys.get(context) != null){
-				activeKeys.get(context).add(key);
+			if(activeKeys.get(context) == null){
+				activeKeys.put(context, new HashSet<>());
 			}
+			activeKeys.get(context).add(key);
 		}
 
 	}
@@ -168,10 +169,9 @@ public class WindowMultiPassOperator<K, IN1, IN2, R, S, W2 extends Window>
 
 	public void processElement2(StreamRecord<IN2> element) throws Exception {
 		logger.info(getRuntimeContext().getIndexOfThisSubtask() + ":: TWOWIN Received from FEEDBACK - " + element);
+		activeIterations.add(element.getProgressContext());
 		superstepWindow.setCurrentKey(feedbackKeying.getKey(element.getValue()));
-		if (activeIterations.contains(element.getProgressContext())) {
-			superstepWindow.processElement(element);
-		}
+		superstepWindow.processElement(element);
 	}
 
 	public void processWatermark1(Watermark mark) throws Exception {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowMultiPassOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/windowing/WindowMultiPassOperator.java
@@ -123,6 +123,7 @@ public class WindowMultiPassOperator<K, IN1, IN2, R, S, W2 extends Window>
 
 		stateHandl = new InnerLoopStateHandl();
 		((IterativeWindowStream.StepWindowFunction) ((InternalIterableWindowFunction) superstepWindow.getUserFunction()).getWrappedFunction()).setManagedLoopStateHandl(stateHandl);
+		((IterativeWindowStream.StepWindowFunction) ((InternalIterableWindowFunction) superstepWindow.getUserFunction()).getWrappedFunction()).setWindowMultiPassOperator(this);
 
 		this.containingTask = containingTask;
 		this.entryBuffer = new HashMap<>();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/MultiPassWindowOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/MultiPassWindowOperatorTest.java
@@ -138,10 +138,11 @@ public class MultiPassWindowOperatorTest extends TestLogger {
 		
 		String lazyCheck = 
 			"[Record @ [3999, 1] : Left((1,1)), Record @ [3999, 1] : Left((2,2)), Watermark @ [3999, 0], " +
-			"Record @ [3999, 2] : Left((1,1)), Watermark @ [3999, 1], " +
+			"Record @ [3999, 2] : Left((2,1)), Watermark @ [3999, 1], " +
 			"Record @ [4999, 1] : Left((1,3)), Record @ [4999, 1] : Left((2,3)), Watermark @ [4999, 0], Watermark @ [3999, 2], " +
-			"Record @ [4999, 2] : Left((1,2)), Record @ [4999, 2] : Left((2,1)), Watermark @ [4999, 1], " +
-			"Record @ [4999, 0] : Right((1,3)), Record @ [4999, 0] : Right((2,3)), Watermark @ [3999, 9223372036854775807]#, Watermark @ [4999, 2], " +
+			"Record @ [4999, 2] : Left((1,2)), Record @ [4999, 2] : Left((2,2)), Watermark @ [4999, 1], " +
+			"Record @ [4999, 0] : Right((1,3)), Record @ [4999, 0] : Right((2,3)), Watermark @ [3999, 9223372036854775807]#, " +
+			"Record @ [4999, 3] : Left((1,1)), Record @ [4999, 3] : Left((2,1)), Watermark @ [4999, 2], Watermark @ [4999, 3], " +
 			"Record @ [4999, 0] : Right((1,3)), Record @ [4999, 0] : Right((2,3)), Watermark @ [4999, 9223372036854775807]#]";
 		
 		ConcurrentLinkedQueue<Object> history = new ConcurrentLinkedQueue<>();
@@ -172,6 +173,7 @@ public class MultiPassWindowOperatorTest extends TestLogger {
 		progressStep(testHarness, history);
 		System.err.println(testHarness.getOutput());
 		//CLEANUP
+		progressStep(testHarness, history);
 		progressStep(testHarness, history);
 		progressStep(testHarness, history);
 		progressStep(testHarness, history);


### PR DESCRIPTION
Since this isn't really a big project with many developers I allowed myself to break convention and address multiple small issues here since I think it makes it easier to look through. If this is not desired, I can break it up as well. Just tell me and I will do so. I also have some problems with tests, some of which fail even with the unchanged version, so I didn't give them the weight one usually should.

## What is the purpose of the change

- allow correct access to persistent state and loop state in the step function (the key the state was accesed from was incorrect before)

-  Allow processing of feedback messages in parallel instances that did not receive an entry message

- Make finalize be called for all keys that received any mesages (entry or feedback): I found the previous convention (received entry message OR state changed) a bit arbitrary, I think finalize should be either ONLY called for keys where state was changed or for ALL that were active at any point in the entry or step function, here I tried the second version, but I think both have pros and cons.

- a small change to the superstep number in entry

## Brief change log

- StepWindowFunction knows the WindowMultiPassOperator and sets its current key to the appropriate key before calling the step function. This allows correct access to state, which was not the case before.

- removed the check for the iteration being active in processElement2() in WindowMultiPassOperator to fix issue #3. The previous check did not make 100% sense because it blocked the processing of feedback messages in parallel instances that did not receive an entry message. This change might cause problems in some cases that I have not encountered, but I cannot really tell and it clearly wasn't working before. Maybe someone else understands better why the previous check was thought necessary and a working solution can be found.

- in WindowMultiPassOperator: add all keys for which processElement2() is called to active keys. Again, this might cause problems that I am simply not aware of, because they don't seem to occur in my use cases. If there was a reason for the previous model and this doen't work, I would like to get a hint of what I seem to overlook.

- removed markActive from ManagedLoopStateHandl because of the change in how active keys are recognized

- changed superstep in LoopContext for entry funtion from 0 to 1 because the next superstep was already 2, so this seems more consistent

- changed the test MultiPassWindowOperatorTest because the old comparison result seemed to be wrong (the outlined problem with the state). Altough I tried to manually check if it is now correct, it would be nice if you could manually verify my impression as well.

## Verifying this change

Unfortunately I didn't add any tests because I don't think the changes are that dramatic. I mostly just verified with a few of my own limited example programs. As mentioned I actually edited the MultiPassWindowOperatorTest to fit my new results because I simply think the old test was incorrect (described above).


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
